### PR TITLE
Update Type-7 name to correct an old typo

### DIFF
--- a/data/ships/type_7_transport.json
+++ b/data/ships/type_7_transport.json
@@ -2,7 +2,7 @@
   "type_7_transport": {
     "properties": {
       "grp": "fr",
-      "name": "Type-7 Transport",
+      "name": "Type-7 Transporter",
       "manufacturer": "Lakon",
       "class": 3,
       "cost": 16881511,


### PR DESCRIPTION
According to the screenshot provide by SpyTec in #37, the correct name of the Type-7 is "Type-7 Transporter"
