### PR TITLE
Responsive CSS for Outfitting screen

### DIFF
--- a/app/less/app.less
+++ b/app/less/app.less
@@ -1,5 +1,6 @@
 @import 'colors';
 @import 'fonts';
+@import 'responsive';
 @import 'utilities';
 @import 'icons';
 @import 'background-images';

--- a/app/less/header.less
+++ b/app/less/header.less
@@ -79,6 +79,15 @@ header {
     -webkit-overflow-scrolling: touch;
     max-height: 400px;
 
+    .tablet({
+      font-size: 1.1em;
+      max-height: 800px;
+
+      a {
+        padding: 0.3em 0;
+      }
+    });
+
     &.dbl {
       -webkit-column-count: 2; /* Chrome, Safari, Opera */
       -moz-column-count: 2; /* Firefox */

--- a/app/less/header.less
+++ b/app/less/header.less
@@ -47,26 +47,21 @@ header {
     color: @warning;
     // Less than 600px screen width: hide text
 
-
     &.disabled {
       color: @warning-disabled;
       cursor: default;
     }
 
     &.selected {
-        background-color: @bgBlack;
+      background-color: @bgBlack;
     }
 
     .menu-item-label {
-        @media screen and (min-width: 541px) {
-            margin-left: 1em;
-        }
-        @media screen and (max-width: 540px) {
-            margin-left: 0.5em;
-        }
-        @media screen and (max-width: 520px) {
-            display: none;
-        }
+      margin-left: 1em;
+
+      .medPhone({
+        display: none;
+      });
     }
   }
 

--- a/app/less/outfit.less
+++ b/app/less/outfit.less
@@ -39,6 +39,10 @@
         width: 100%;
         border-collapse: collapse;
         font-size: 0.8em;
+
+        tbody td {
+            padding: 0 0.5em;
+        }
     }
 }
 
@@ -58,6 +62,11 @@
     &:focus {
       border: 1px solid @primary;
       color: @primary;
+    }
+  }
+  @media screen and (max-width: 340px) {
+    button {
+      padding: 0.25em;
     }
   }
 }

--- a/app/less/outfit.less
+++ b/app/less/outfit.less
@@ -11,6 +11,14 @@
     //font-size: 0.8em;
   });
 
+  &>.list {
+    @media screen and (max-width: 1000px) {
+      width: 49%;
+    }
+    @media screen and (max-width: 600px) {
+      width: 100%;
+    }
+  }
 }
 
 #overview {
@@ -73,5 +81,17 @@
 
     @media screen and (max-width: 640px) {
         display: none;
+    }
+}
+
+#jumpRange {
+    width: 50%;
+    padding: 0 0.5em;
+
+    @media screen and (max-width: 1000px) {
+        float: right;
+        clear: both;
+        display: block;
+        width: 100% !important;
     }
 }

--- a/app/less/outfit.less
+++ b/app/less/outfit.less
@@ -7,6 +7,8 @@
 
   .tablet({
     width: 100%;
+    font-size: 1.2em;
+    max-width: 1600px;
   });
 
   &>.list {
@@ -21,6 +23,10 @@
 }
 
 #overview {
+  .tablet({
+      font-size: 0.9em;
+  });
+
   h1 {
     margin: 0;
     float: left;
@@ -31,7 +37,8 @@
 #summary {
   overflow-x: auto;
   width: 100%;
-  margin: 1em 0 2em 0;
+  margin: 1em 0 1em 0;
+  padding-bottom: 1em;
   
   #summaryTable {
     .user-select-none();
@@ -87,7 +94,7 @@
 .outfit-button-label {
   margin-left: 0.5em;
 
-  .largePhone({
+  .smallTablet({
     display: none;
   });
 }

--- a/app/less/outfit.less
+++ b/app/less/outfit.less
@@ -29,20 +29,20 @@
 }
 
 #summary {
-    overflow-x: auto;
+  overflow-x: auto;
+  width: 100%;
+  margin: 1em 0 2em 0;
+  
+  #summaryTable {
+    .user-select-none();
     width: 100%;
-    margin: 1em 0 2em 0;
+    border-collapse: collapse;
+    font-size: 0.8em;
 
-    #summaryTable {
-        .user-select-none();
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 0.8em;
-
-        tbody td {
-            padding: 0 0.5em;
-        }
+    tbody td {
+        padding: 0 0.5em;
     }
+  }
 }
 
 #build {

--- a/app/less/outfit.less
+++ b/app/less/outfit.less
@@ -7,17 +7,16 @@
 
   .tablet({
     width: 100%;
-    //min-width: 750px;
-    //font-size: 0.8em;
   });
 
   &>.list {
-    @media screen and (max-width: 1000px) {
+    .tablet({
       width: 49%;
-    }
-    @media screen and (max-width: 600px) {
+    });
+
+    .largePhone({
       width: 100%;
-    }
+    });
   }
 }
 
@@ -64,10 +63,10 @@
       color: @primary;
     }
   }
-  @media screen and (max-width: 340px) {
-    button {
+  button {
+    .smallPhone({
       padding: 0.25em;
-    }
+    });
   }
 }
 
@@ -86,21 +85,21 @@
 }
 
 .outfit-button-label {
-    margin-left: 0.5em;
+  margin-left: 0.5em;
 
-    @media screen and (max-width: 640px) {
-        display: none;
-    }
+  .largePhone({
+    display: none;
+  });
 }
 
 #jumpRange {
-    width: 50%;
-    padding: 0 0.5em;
+  width: 50%;
+  padding: 0 0.5em;
 
-    @media screen and (max-width: 1000px) {
-        float: right;
-        clear: both;
-        display: block;
-        width: 100% !important;
-    }
+  .tablet({
+    float: right;
+    clear: both;
+    display: block;
+    width: 100% !important;
+  });
 }

--- a/app/less/outfit.less
+++ b/app/less/outfit.less
@@ -7,8 +7,8 @@
 
   .tablet({
     width: 100%;
-    min-width: 750px;
-    font-size: 0.8em;
+    //min-width: 750px;
+    //font-size: 0.8em;
   });
 
 }
@@ -22,15 +22,16 @@
 }
 
 #summary {
-  .user-select-none();
-  width: 100%;
-  margin: 1em 0;
-  font-size: 0.8em;
-  border-collapse: collapse;
+    overflow-x: auto;
+    width: 100%;
+    margin: 1em 0 2em 0;
 
-  tbody td {
-    padding: 0 0.5em;
-  }
+    #summaryTable {
+        .user-select-none();
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8em;
+    }
 }
 
 #build {
@@ -65,4 +66,12 @@
  .slot {
     clear: left;
   }
+}
+
+.outfit-button-label {
+    margin-left: 0.5em;
+
+    @media screen and (max-width: 640px) {
+        display: none;
+    }
 }

--- a/app/less/responsive.less
+++ b/app/less/responsive.less
@@ -21,6 +21,13 @@
   }
 }
 
+.smallTablet(@rules) {
+  @media only screen and /*(min-width: 641px) and */(max-width: 820px) {
+    @rules();
+  }
+}
+
+
 .tablet(@rules) {
   @media only screen and /*(min-width: 601px) and */(max-width: 1024px) {
     @rules();

--- a/app/less/responsive.less
+++ b/app/less/responsive.less
@@ -1,0 +1,28 @@
+﻿// Screens less than 1024 wide
+// More will be added over time to support mobile devices better
+// These are designed to trickle down. So tablet styles will apply to tablet and smaller, etc
+// To overwrite, put the smallest devices at the bottom
+
+.smallPhone(@rules) {
+  @media only screen and (max-width: 350px) {
+    @rules();
+  }
+}
+
+.medPhone(@rules) {
+  @media only screen and /*(min-width: 351px) and */ (max-width: 550px) {
+    @rules();
+  }
+}
+
+.largePhone(@rules) {
+  @media only screen and /*(min-width: 551px) and */ (max-width: 640px) {
+    @rules();
+  }
+}
+
+.tablet(@rules) {
+  @media only screen and /*(min-width: 601px) and */(max-width: 1024px) {
+    @rules();
+  }
+}

--- a/app/less/shipyard.less
+++ b/app/less/shipyard.less
@@ -16,9 +16,9 @@ a.ship {
   text-align: right;
   .user-select-none();
 
-  @media screen and (max-width: 350px) {
+  .smallPhone({
     width: 16em;
-  }
+  });
 
   h2 {
     width: 100%;

--- a/app/less/shipyard.less
+++ b/app/less/shipyard.less
@@ -16,6 +16,10 @@ a.ship {
   text-align: right;
   .user-select-none();
 
+  @media screen and (max-width: 350px) {
+    width: 16em;
+  }
+
   h2 {
     width: 100%;
     margin: 0;

--- a/app/less/slot.less
+++ b/app/less/slot.less
@@ -16,6 +16,18 @@
     padding-left: 0.5em;
     font-weight: normal;
   }
+
+  @media screen and (max-width: 1000px) {
+    width: 50%;
+    
+    h1 {
+        margin: 1em 0 0 0;
+    }
+  }
+
+  @media screen and (max-width: 610px) {
+    width: 100%;
+  }
 }
 
 .slot {

--- a/app/less/slot.less
+++ b/app/less/slot.less
@@ -17,17 +17,17 @@
     font-weight: normal;
   }
 
-  @media screen and (max-width: 1000px) {
+  .tablet({
     width: 50%;
     
     h1 {
         margin: 1em 0 0 0;
     }
-  }
+  });
 
-  @media screen and (max-width: 610px) {
+  .largePhone({
     width: 100%;
-  }
+  });
 }
 
 .slot {

--- a/app/less/utilities.less
+++ b/app/less/utilities.less
@@ -29,11 +29,3 @@
   -ms-user-select: none;
   user-select: none;
 }
-
-// Screens less than 1024 wide
-// More will be added over time to support mobile devices better
-.tablet(@rules) {
-  @media only screen and (min-width: 300px) and (max-width: 1024px) {
-    @rules();
-  }
-}

--- a/app/views/page-outfit.html
+++ b/app/views/page-outfit.html
@@ -180,7 +180,7 @@
     </div>
   </div>
 
-  <div id="internal" class="slot-group r">
+  <div id="internal" class="slot-group l">
     <h1>Internal Compartments</h1>
     <div class="slot" ng-repeat="i in ship.internal" ng-click="selectSlot($event, i)" ng-class="{selected: selectedSlot==i}">
       <div slot-internal class="details" slot="i" lbl="igMap[i.c.grp]" ft="ft"></div>

--- a/app/views/page-outfit.html
+++ b/app/views/page-outfit.html
@@ -1,270 +1,270 @@
 <div id="outfit">
 
-    <div id="overview">
-        <h1 ng-bind="ship.name"></h1>
-        <div id="build">
-            <input ng-model="buildName" ng-change="bnChange()" placeholder="Enter Build Name" maxlength="50" />
-            <button ng-click="saveBuild()" ng-disabled="!buildName || savedCode && code == savedCode || !canSave">
-                <svg class="icon lg "><use xlink:href="#floppy-disk"></use></svg><span class="outfit-button-label">Save</span>
-            </button>
-            <button ng-click="reloadBuild()" ng-disabled="!savedCode || code == savedCode">
-                <svg class="icon lg"><use xlink:href="#spinner11"></use></svg><span class="outfit-button-label">Reload</span>
-            </button>
-            <button class="danger" ng-click="deleteBuild()" ng-disabled="!savedCode">
-                <svg class="icon lg"><use xlink:href="#bin"></use></svg>
-            </button>
-            <button ui-sref="outfit({shipId: ship.id,code:null, bn: buildName})" ng-disabled="!code">
-                <svg class="icon lg"><use xlink:href="#switch"></use></svg><span class="outfit-button-label">Reset</span>
-            </button>
-        </div>
+  <div id="overview">
+    <h1 ng-bind="ship.name"></h1>
+    <div id="build">
+      <input ng-model="buildName" ng-change="bnChange()" placeholder="Enter Build Name" maxlength="50" />
+      <button ng-click="saveBuild()" ng-disabled="!buildName || savedCode && code == savedCode || !canSave">
+        <svg class="icon lg "><use xlink:href="#floppy-disk"></use></svg><span class="outfit-button-label">Save</span>
+      </button>
+      <button ng-click="reloadBuild()" ng-disabled="!savedCode || code == savedCode">
+        <svg class="icon lg"><use xlink:href="#spinner11"></use></svg><span class="outfit-button-label">Reload</span>
+      </button>
+      <button class="danger" ng-click="deleteBuild()" ng-disabled="!savedCode">
+        <svg class="icon lg"><use xlink:href="#bin"></use></svg>
+      </button>
+      <button ui-sref="outfit({shipId: ship.id,code:null, bn: buildName})" ng-disabled="!code">
+        <svg class="icon lg"><use xlink:href="#switch"></use></svg><span class="outfit-button-label">Reset</span>
+      </button>
+    </div>
+  </div>
+
+  <div id="summary">
+    <table id="summaryTable">
+      <thead>
+        <tr class="main">
+          <th rowspan="2">Size</th>
+          <th colspan="3">Maneouverability</th>
+          <th colspan="2">Mass</th>
+          <th rowspan="2">Cargo</th>
+          <th rowspan="2">Fuel</th>
+          <th rowspan="2">Armour</th>
+          <th rowspan="2">Shields</th>
+          <th colspan="2">Power</th>
+          <th colspan="2">Jump Range</th>
+        </tr>
+        <tr>
+          <th>Agility</th>
+          <th>Speed</th>
+          <th>Boost</th>
+          <th class="lft">Unladen</th>
+          <th>Laden</th>
+          <th class="lft">Retracted</th>
+          <th>Deployed</th>
+          <th class="lft">Unladen</th>
+          <th>Laden</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td ng-bind="SZ[ship.class]"></td>
+          <td>{{ship.agility}}/10</td>
+          <td>{{fRound(ship.speed)}} <u>m/s</u></td>
+          <td>{{fRound(ship.boost)}} <u>m/s</u></td>
+          <td>{{fRound(ship.unladenMass)}} <u>T</u></td>
+          <td>{{fRound(ship.ladenMass)}} <u>T</u></td>
+          <td>{{fRound(ship.cargoCapacity)}} <u>T</u></td>
+          <td>{{fRound(ship.fuelCapacity)}} <u>T</u></td>
+          <td>{{ship.armourTotal}} <span ng-if="ship.armourAdded">({{ship.armour}} + {{ship.armourAdded}})</span></td>
+          <td>{{fRound(ship.shieldStrength)}} <u>Mj</u> <span ng-if="ship.shieldMultiplier > 1">({{fRPct(ship.shieldMultiplier)}})</span></td>
+          <td>{{fPwr(ship.powerRetracted)}} <u>MW ({{fPct(ship.powerRetracted/ship.powerAvailable)}})</u></td>
+          <td>{{fPwr(ship.powerDeployed)}} <u>MW ({{fPct(ship.powerDeployed/ship.powerAvailable)}})</u></td>
+          <td>{{fRound(ship.unladenJumpRange)}} <u>LY</u></td>
+          <td>{{fRound(ship.ladenJumpRange)}} <u>LY</u></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div id="standard" class="slot-group l">
+    <h1>Standard</h1>
+    <div class="slot" ng-click="selectSlot($event, ship.bulkheads)" ng-class="{selected: selectedSlot==ship.bulkheads}">
+      <div class="details">
+        <div class="sz"><span>8</span></div>
+        <div class="l">Bulkheads</div>
+        <div class="r">{{ship.bulkheads.c.mass}} <u>T</u></div>
+        <div class="cl l">{{ship.bulkheads.c.name}}</div>
+      </div>
+      <div class="select" ng-if="selectedSlot==ship.bulkheads" ng-click="select('b',ship.bulkheads,$event)">
+        <ul>
+          <li class="lc" ng-class="{active: ship.bulkheads.id=='0'}" cpid="0">Lightweight Alloy</li>
+          <li class="lc" ng-class="{active: ship.bulkheads.id=='1'}" cpid="1">Reinforced Alloy</li>
+          <li class="lc" ng-class="{active: ship.bulkheads.id=='2'}" cpid="2">Military Grade Composite</li>
+          <li class="lc" ng-class="{active: ship.bulkheads.id=='3'}" cpid="3">Mirrored Surface Composite</li>
+          <li class="lc" ng-class="{active: ship.bulkheads.id=='4'}" cpid="4">Reactive Surface Composite</li>
+        </ul>
+      </div>
+    </div>
+    <div class="slot" ng-click="selectSlot($event, pp)" ng-class="{selected: selectedSlot==pp}">
+      <div class="details">
+        <div class="sz">{{::pp.maxClass}}</div>
+        <div class="l">{{pp.id}} Power Plant</div>
+        <div class="r">{{pp.c.mass}} <u>T</u></div>
+        <div class="cb"></div>
+        <div class="l">Efficiency: {{pp.c.eff}}</div>
+        <div class="l">Power: {{pp.c.pGen}} <u>MW</u></div>
+      </div>
+      <div component-select class="select" s="pp" opts="availCS.common[0]" ng-if="selectedSlot==pp" ng-click="select('c',pp,$event)"></div>
+    </div>
+    <div class="slot" ng-click="selectSlot($event, th)" ng-class="{selected: selectedSlot==th}">
+      <div class="details">
+        <div class="sz">{{::th.maxClass}}</div>
+        <div class="l">{{th.id}} Thrusters</div>
+        <div class="r">{{th.c.mass}} <u>T</u></div>
+        <div class="cb"></div>
+        <div class="l">Opt: {{th.c.optmass}} <u>T</u></div>
+        <div class="l">Max: {{th.c.maxmass}} <u>T</u></div>
+      </div>
+      <div component-select class="select" s="th" mass="ship.unladenMass" opts="availCS.common[1]" ng-if="selectedSlot==th" ng-click="select('c',th,$event)"></div>
+    </div>
+    <div class="slot" ng-click="selectSlot($event, fsd)" ng-class="{selected: selectedSlot==fsd}">
+      <div class="details">
+        <div class="sz">{{::fsd.maxClass}}</div>
+        <div class="l">{{fsd.id}} Frame Shift Drive</div>
+        <div class="r cr">{{fsd.c.mass}} <u>T</u></div>
+        <div class="cb"></div>
+        <div class="l">Opt: {{fsd.c.optmass}} <u>T</u></div>
+        <div class="l">Max Fuel: {{fsd.c.maxfuel}} <u>T</u></div>
+      </div>
+      <div component-select class="select" s="fsd" opts="availCS.common[2]" ng-if="selectedSlot==fsd" ng-click="select('c',fsd,$event)"></div>
+    </div>
+    <div class="slot" ng-click="selectSlot($event, ls)" ng-class="{selected: selectedSlot==ls}">
+      <div class="details">
+        <div class="sz">{{::ls.maxClass}}</div>
+        <div class="l">{{ls.id}} Life Support</div>
+        <div class="r">{{ls.c.mass}} <u>T</u></div>
+        <div class="cb"></div>
+        <div class="l">Time: {{fTime(ls.c.time)}}</div>
+      </div>
+      <div component-select class="select" s="ls" opts="availCS.common[3]" ng-if="selectedSlot==ls" ng-click="select('c',ls,$event)"></div>
+    </div>
+    <div class="slot" ng-click="selectSlot($event, pd)" ng-class="{selected: selectedSlot==pd}">
+      <div class="details">
+        <div class="sz">{{::pd.maxClass}}</div>
+        <div class="l">{{pd.id}} Power Distributor</div>
+        <div class="r">{{pd.c.mass}} <u>T</u></div>
+        <div class="cb"></div>
+        <div class="l">Wep: {{pd.c.weaponcapacity}} <u>Mj</u> / {{pd.c.weaponrecharge}} <u>MW</u></div>
+        <div class="l">Sys: {{pd.c.systemcapacity}} <u>Mj</u> / {{pd.c.systemrecharge}} <u>MW</u></div>
+        <div class="l">Eng: {{pd.c.enginecapacity}} <u>Mj</u> / {{pd.c.enginerecharge}} <u>MW</u></div>
+      </div>
+      <div component-select class="select" s="pd" opts="availCS.common[4]" ng-if="selectedSlot==pd" ng-click="select('c',pd,$event)"></div>
+    </div>
+    <div class="slot" ng-click="selectSlot($event, ss)" ng-class="{selected: selectedSlot==ss}">
+      <div class="details">
+        <div class="sz">{{::ss.maxClass}}</div>
+        <div class="l">{{ss.id}} Sensors</div>
+        <div class="r">{{ss.c.mass}} <u>T</u></div>
+        <div class="cb"></div>
+        <div class="l">{{ss.c.range}} <u>KM</u></div>
+      </div>
+      <div component-select class="select" s="ss" opts="availCS.common[5]" ng-if="selectedSlot==ss" ng-click="select('c',ss,$event)"></div>
+    </div>
+    <div class="slot" ng-click="selectSlot($event, ft)" ng-class="{selected: selectedSlot==ft}">
+      <div class="details">
+        <div class="sz">{{::ft.maxClass}}</div>
+        <div class="l">{{ft.id}} Fuel Tank</div>
+        <div class="r">{{ft.c.capacity}} <u>T</u></div>
+      </div>
+      <div component-select class="select" s="ft" opts="availCS.common[6]" ng-if="selectedSlot==ft" ng-click="select('c',ft,$event)"></div>
+    </div>
+  </div>
+
+  <div id="hardpoints" class="slot-group l">
+    <h1>HardPoints</h1>
+    <div class="slot" ng-repeat="h in ship.hardpoints | filter:{maxClass: '!0'}" ng-click="selectSlot($event, h)" ng-class="{selected: selectedSlot==h}">
+      <div slot-hardpoint class="details" hp="h" size="HPC[h.maxClass]" lbl="hgMap[h.c.grp]"></div>
+      <div class="select" ng-class="{hardpoint: h.maxClass > 0}" ng-if="selectedSlot==h" ng-click="select('h',h,$event)">
+        <div component-select s="h" groups="availCS.getHps(h.maxClass)"></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="utility" class="slot-group l">
+    <h1>Utility Mounts</h1>
+    <div class="slot" ng-repeat="h in ship.hardpoints | filter:{maxClass: '0'}" ng-click="selectSlot($event, h)" ng-class="{selected: selectedSlot==h}">
+      <div slot-hardpoint class="details" hp="h" size="HPC[h.maxClass]" lbl="hgMap[h.c.grp]"></div>
+      <div class="select" ng-class="{hardpoint: h.maxClass > 0}" ng-if="selectedSlot==h" ng-click="select('h',h,$event)">
+        <div component-select s="h" groups="availCS.getHps(h.maxClass)"></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="internal" class="slot-group r">
+    <h1>Internal Compartments</h1>
+    <div class="slot" ng-repeat="i in ship.internal" ng-click="selectSlot($event, i)" ng-class="{selected: selectedSlot==i}">
+      <div slot-internal class="details" slot="i" lbl="igMap[i.c.grp]" ft="ft"></div>
+      <div class="select" ng-if="selectedSlot==i" ng-click="select('i',i,$event)">
+        <div component-select s="i" groups="availCS.getInts(i.maxClass)"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="cb"></div>
+
+  <div class="list l">
+    <div class="header">Power Use</div>
+    <div class="items">
+      <div class="primary-disabled">Generated</div>
+      <div ng-if="pp.c.pGen" class="item common enabled untoggleable">
+        <div class="lbl">{{pp.c.class}}{{pp.c.rating}} Power Plant</div><div class="val">{{fPwr(pp.c.pGen)}}</div>
+      </div>
+      <div class="primary-disabled">Standard</div>
+      <div ng-repeat="c in ship.common" ng-if="c.c.power" class="item common" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
+        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{CArr[$index]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
+      </div>
+      <div class="item common consumer" ng-class="{enabled:ship.cargoScoop.enabled}" ng-click="togglePwr(ship.cargoScoop)">
+        <div class="lbl">1H Cargo Scoop</div><div class="val">{{fPwr(ship.cargoScoop.c.power)}}</div>
+      </div>
+      <div class="primary-disabled">Hardpoints</div>
+      <div ng-repeat="c in ship.hardpoints" ng-if="c.c.power" class="item hardpoints" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
+        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || hgMap[c.c.grp]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
+      </div>
+      <div class="primary-disabled">Internal</div>
+      <div ng-repeat="c in ship.internal" ng-if="c.c.power" class="item internal" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
+        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || igMap[c.c.grp]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
+      </div>
     </div>
 
-    <div id="summary">
-        <table id="summaryTable">
-            <thead>
-                <tr class="main">
-                    <th rowspan="2">Size</th>
-                    <th colspan="3">Maneouverability</th>
-                    <th colspan="2">Mass</th>
-                    <th rowspan="2">Cargo</th>
-                    <th rowspan="2">Fuel</th>
-                    <th rowspan="2">Armour</th>
-                    <th rowspan="2">Shields</th>
-                    <th colspan="2">Power</th>
-                    <th colspan="2">Jump Range</th>
-                </tr>
-                <tr>
-                    <th>Agility</th>
-                    <th>Speed</th>
-                    <th>Boost</th>
-                    <th class="lft">Unladen</th>
-                    <th>Laden</th>
-                    <th class="lft">Retracted</th>
-                    <th>Deployed</th>
-                    <th class="lft">Unladen</th>
-                    <th>Laden</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td ng-bind="SZ[ship.class]"></td>
-                    <td>{{ship.agility}}/10</td>
-                    <td>{{fRound(ship.speed)}} <u>m/s</u></td>
-                    <td>{{fRound(ship.boost)}} <u>m/s</u></td>
-                    <td>{{fRound(ship.unladenMass)}} <u>T</u></td>
-                    <td>{{fRound(ship.ladenMass)}} <u>T</u></td>
-                    <td>{{fRound(ship.cargoCapacity)}} <u>T</u></td>
-                    <td>{{fRound(ship.fuelCapacity)}} <u>T</u></td>
-                    <td>{{ship.armourTotal}} <span ng-if="ship.armourAdded">({{ship.armour}} + {{ship.armourAdded}})</span></td>
-                    <td>{{fRound(ship.shieldStrength)}} <u>Mj</u> <span ng-if="ship.shieldMultiplier > 1">({{fRPct(ship.shieldMultiplier)}})</span></td>
-                    <td>{{fPwr(ship.powerRetracted)}} <u>MW ({{fPct(ship.powerRetracted/ship.powerAvailable)}})</u></td>
-                    <td>{{fPwr(ship.powerDeployed)}} <u>MW ({{fPct(ship.powerDeployed/ship.powerAvailable)}})</u></td>
-                    <td>{{fRound(ship.unladenJumpRange)}} <u>LY</u></td>
-                    <td>{{fRound(ship.ladenJumpRange)}} <u>LY</u></td>
-                </tr>
-            </tbody>
-        </table>
+    <table>
+      <thead><tr><td>Retracted</td><td>Deployed</td></tr></thead>
+      <tbody>
+        <tr>
+          <td>{{fPwr(ship.powerRetracted)}} <u>MW</u> ({{fPct(ship.powerRetracted/ship.powerAvailable)}})</td>
+          <td>{{fPwr(ship.powerDeployed)}} <u>MW</u> ({{fPct(ship.powerDeployed/ship.powerAvailable)}})</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="list r">
+    <div class="header">Costs</div>
+    <div class="items">
+      <div class="item" ng-class="{enabled:ship.incCost}" ng-click="toggleCost(ship)">
+        <div class="lbl">{{ship.name}}</div><div class="val">{{fCrd(ship.cost)}}</div>
+      </div>
+      <div class="item" ng-class="{enabled:ship.bulkheads.incCost}" ng-click="toggleCost(ship.bulkheads)" ng-if="ship.bulkheads.c.cost">
+        <div class="lbl">{{ship.bulkheads.c.name}}</div><div class="val">{{fCrd(ship.bulkheads.c.cost)}}</div>
+      </div>
+      <div ng-repeat="c in ship.common" ng-if="c.c.cost" class="item common" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
+        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{CArr[$index]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
+      </div>
+      <div ng-repeat="c in ship.hardpoints" ng-if="c.c.cost" class="item hardpoints" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
+        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || hgMap[c.c.grp]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
+      </div>
+      <div ng-repeat="c in ship.internal" ng-if="c.c.cost" class="item internal" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
+        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || igMap[c.c.grp]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
+      </div>
     </div>
+    <table>
+      <thead><tr><td>Insurance</td><td>Total</td></tr></thead>
+      <tbody>
+        <tr>
+          <td>{{fCrd(ship.totalCost * insurance.current.pct)}} <u>CR</u></td>
+          <td>{{fCrd(ship.totalCost)}} <u>CR</u></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 
-    <div id="standard" class="slot-group l">
-        <h1>Standard</h1>
-        <div class="slot" ng-click="selectSlot($event, ship.bulkheads)" ng-class="{selected: selectedSlot==ship.bulkheads}">
-            <div class="details">
-                <div class="sz"><span>8</span></div>
-                <div class="l">Bulkheads</div>
-                <div class="r">{{ship.bulkheads.c.mass}} <u>T</u></div>
-                <div class="cl l">{{ship.bulkheads.c.name}}</div>
-            </div>
-            <div class="select" ng-if="selectedSlot==ship.bulkheads" ng-click="select('b',ship.bulkheads,$event)">
-                <ul>
-                    <li class="lc" ng-class="{active: ship.bulkheads.id=='0'}" cpid="0">Lightweight Alloy</li>
-                    <li class="lc" ng-class="{active: ship.bulkheads.id=='1'}" cpid="1">Reinforced Alloy</li>
-                    <li class="lc" ng-class="{active: ship.bulkheads.id=='2'}" cpid="2">Military Grade Composite</li>
-                    <li class="lc" ng-class="{active: ship.bulkheads.id=='3'}" cpid="3">Mirrored Surface Composite</li>
-                    <li class="lc" ng-class="{active: ship.bulkheads.id=='4'}" cpid="4">Reactive Surface Composite</li>
-                </ul>
-            </div>
-        </div>
-        <div class="slot" ng-click="selectSlot($event, pp)" ng-class="{selected: selectedSlot==pp}">
-            <div class="details">
-                <div class="sz">{{::pp.maxClass}}</div>
-                <div class="l">{{pp.id}} Power Plant</div>
-                <div class="r">{{pp.c.mass}} <u>T</u></div>
-                <div class="cb"></div>
-                <div class="l">Efficiency: {{pp.c.eff}}</div>
-                <div class="l">Power: {{pp.c.pGen}} <u>MW</u></div>
-            </div>
-            <div component-select class="select" s="pp" opts="availCS.common[0]" ng-if="selectedSlot==pp" ng-click="select('c',pp,$event)"></div>
-        </div>
-        <div class="slot" ng-click="selectSlot($event, th)" ng-class="{selected: selectedSlot==th}">
-            <div class="details">
-                <div class="sz">{{::th.maxClass}}</div>
-                <div class="l">{{th.id}} Thrusters</div>
-                <div class="r">{{th.c.mass}} <u>T</u></div>
-                <div class="cb"></div>
-                <div class="l">Opt: {{th.c.optmass}} <u>T</u></div>
-                <div class="l">Max: {{th.c.maxmass}} <u>T</u></div>
-            </div>
-            <div component-select class="select" s="th" mass="ship.unladenMass" opts="availCS.common[1]" ng-if="selectedSlot==th" ng-click="select('c',th,$event)"></div>
-        </div>
-        <div class="slot" ng-click="selectSlot($event, fsd)" ng-class="{selected: selectedSlot==fsd}">
-            <div class="details">
-                <div class="sz">{{::fsd.maxClass}}</div>
-                <div class="l">{{fsd.id}} Frame Shift Drive</div>
-                <div class="r cr">{{fsd.c.mass}} <u>T</u></div>
-                <div class="cb"></div>
-                <div class="l">Opt: {{fsd.c.optmass}} <u>T</u></div>
-                <div class="l">Max Fuel: {{fsd.c.maxfuel}} <u>T</u></div>
-            </div>
-            <div component-select class="select" s="fsd" opts="availCS.common[2]" ng-if="selectedSlot==fsd" ng-click="select('c',fsd,$event)"></div>
-        </div>
-        <div class="slot" ng-click="selectSlot($event, ls)" ng-class="{selected: selectedSlot==ls}">
-            <div class="details">
-                <div class="sz">{{::ls.maxClass}}</div>
-                <div class="l">{{ls.id}} Life Support</div>
-                <div class="r">{{ls.c.mass}} <u>T</u></div>
-                <div class="cb"></div>
-                <div class="l">Time: {{fTime(ls.c.time)}}</div>
-            </div>
-            <div component-select class="select" s="ls" opts="availCS.common[3]" ng-if="selectedSlot==ls" ng-click="select('c',ls,$event)"></div>
-        </div>
-        <div class="slot" ng-click="selectSlot($event, pd)" ng-class="{selected: selectedSlot==pd}">
-            <div class="details">
-                <div class="sz">{{::pd.maxClass}}</div>
-                <div class="l">{{pd.id}} Power Distributor</div>
-                <div class="r">{{pd.c.mass}} <u>T</u></div>
-                <div class="cb"></div>
-                <div class="l">Wep: {{pd.c.weaponcapacity}} <u>Mj</u> / {{pd.c.weaponrecharge}} <u>MW</u></div>
-                <div class="l">Sys: {{pd.c.systemcapacity}} <u>Mj</u> / {{pd.c.systemrecharge}} <u>MW</u></div>
-                <div class="l">Eng: {{pd.c.enginecapacity}} <u>Mj</u> / {{pd.c.enginerecharge}} <u>MW</u></div>
-            </div>
-            <div component-select class="select" s="pd" opts="availCS.common[4]" ng-if="selectedSlot==pd" ng-click="select('c',pd,$event)"></div>
-        </div>
-        <div class="slot" ng-click="selectSlot($event, ss)" ng-class="{selected: selectedSlot==ss}">
-            <div class="details">
-                <div class="sz">{{::ss.maxClass}}</div>
-                <div class="l">{{ss.id}} Sensors</div>
-                <div class="r">{{ss.c.mass}} <u>T</u></div>
-                <div class="cb"></div>
-                <div class="l">{{ss.c.range}} <u>KM</u></div>
-            </div>
-            <div component-select class="select" s="ss" opts="availCS.common[5]" ng-if="selectedSlot==ss" ng-click="select('c',ss,$event)"></div>
-        </div>
-        <div class="slot" ng-click="selectSlot($event, ft)" ng-class="{selected: selectedSlot==ft}">
-            <div class="details">
-                <div class="sz">{{::ft.maxClass}}</div>
-                <div class="l">{{ft.id}} Fuel Tank</div>
-                <div class="r">{{ft.c.capacity}} <u>T</u></div>
-            </div>
-            <div component-select class="select" s="ft" opts="availCS.common[6]" ng-if="selectedSlot==ft" ng-click="select('c',ft,$event)"></div>
-        </div>
+  <div class="list l" id="jumpRange">
+    <div class="header">Jump Range</div>
+    <div class="cen">
+      <div class="chart" area-chart config="jrChart" series="jrSeries"></div>
+      <div slider max="ship.fuelCapacity" unit="'T'" on-change="::fuelChange(val)" style="position:relative; margin: 0 auto;">
+        <svg class="icon xl primary-disabled" style="position:absolute;height: 100%;"><use xlink:href="#fuel"></use></svg>
+      </div>
     </div>
-
-    <div id="hardpoints" class="slot-group l">
-        <h1>HardPoints</h1>
-        <div class="slot" ng-repeat="h in ship.hardpoints | filter:{maxClass: '!0'}" ng-click="selectSlot($event, h)" ng-class="{selected: selectedSlot==h}">
-            <div slot-hardpoint class="details" hp="h" size="HPC[h.maxClass]" lbl="hgMap[h.c.grp]"></div>
-            <div class="select" ng-class="{hardpoint: h.maxClass > 0}" ng-if="selectedSlot==h" ng-click="select('h',h,$event)">
-                <div component-select s="h" groups="availCS.getHps(h.maxClass)"></div>
-            </div>
-        </div>
-    </div>
-
-    <div id="utility" class="slot-group l">
-        <h1>Utility Mounts</h1>
-        <div class="slot" ng-repeat="h in ship.hardpoints | filter:{maxClass: '0'}" ng-click="selectSlot($event, h)" ng-class="{selected: selectedSlot==h}">
-            <div slot-hardpoint class="details" hp="h" size="HPC[h.maxClass]" lbl="hgMap[h.c.grp]"></div>
-            <div class="select" ng-class="{hardpoint: h.maxClass > 0}" ng-if="selectedSlot==h" ng-click="select('h',h,$event)">
-                <div component-select s="h" groups="availCS.getHps(h.maxClass)"></div>
-            </div>
-        </div>
-    </div>
-
-    <div id="internal" class="slot-group r">
-        <h1>Internal Compartments</h1>
-        <div class="slot" ng-repeat="i in ship.internal" ng-click="selectSlot($event, i)" ng-class="{selected: selectedSlot==i}">
-            <div slot-internal class="details" slot="i" lbl="igMap[i.c.grp]" ft="ft"></div>
-            <div class="select" ng-if="selectedSlot==i" ng-click="select('i',i,$event)">
-                <div component-select s="i" groups="availCS.getInts(i.maxClass)"></div>
-            </div>
-        </div>
-    </div>
-
-    <div class="cb"></div>
-
-    <div class="list l">
-        <div class="header">Power Use</div>
-        <div class="items">
-            <div class="primary-disabled">Generated</div>
-            <div ng-if="pp.c.pGen" class="item common enabled untoggleable">
-                <div class="lbl">{{pp.c.class}}{{pp.c.rating}} Power Plant</div><div class="val">{{fPwr(pp.c.pGen)}}</div>
-            </div>
-            <div class="primary-disabled">Standard</div>
-            <div ng-repeat="c in ship.common" ng-if="c.c.power" class="item common" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
-                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{CArr[$index]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
-            </div>
-            <div class="item common consumer" ng-class="{enabled:ship.cargoScoop.enabled}" ng-click="togglePwr(ship.cargoScoop)">
-                <div class="lbl">1H Cargo Scoop</div><div class="val">{{fPwr(ship.cargoScoop.c.power)}}</div>
-            </div>
-            <div class="primary-disabled">Hardpoints</div>
-            <div ng-repeat="c in ship.hardpoints" ng-if="c.c.power" class="item hardpoints" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
-                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || hgMap[c.c.grp]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
-            </div>
-            <div class="primary-disabled">Internal</div>
-            <div ng-repeat="c in ship.internal" ng-if="c.c.power" class="item internal" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
-                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || igMap[c.c.grp]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
-            </div>
-        </div>
-
-        <table>
-            <thead><tr><td>Retracted</td><td>Deployed</td></tr></thead>
-            <tbody>
-                <tr>
-                    <td>{{fPwr(ship.powerRetracted)}} <u>MW</u> ({{fPct(ship.powerRetracted/ship.powerAvailable)}})</td>
-                    <td>{{fPwr(ship.powerDeployed)}} <u>MW</u> ({{fPct(ship.powerDeployed/ship.powerAvailable)}})</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-
-    <div class="list r">
-        <div class="header">Costs</div>
-        <div class="items">
-            <div class="item" ng-class="{enabled:ship.incCost}" ng-click="toggleCost(ship)">
-                <div class="lbl">{{ship.name}}</div><div class="val">{{fCrd(ship.cost)}}</div>
-            </div>
-            <div class="item" ng-class="{enabled:ship.bulkheads.incCost}" ng-click="toggleCost(ship.bulkheads)" ng-if="ship.bulkheads.c.cost">
-                <div class="lbl">{{ship.bulkheads.c.name}}</div><div class="val">{{fCrd(ship.bulkheads.c.cost)}}</div>
-            </div>
-            <div ng-repeat="c in ship.common" ng-if="c.c.cost" class="item common" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
-                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{CArr[$index]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
-            </div>
-            <div ng-repeat="c in ship.hardpoints" ng-if="c.c.cost" class="item hardpoints" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
-                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || hgMap[c.c.grp]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
-            </div>
-            <div ng-repeat="c in ship.internal" ng-if="c.c.cost" class="item internal" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
-                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || igMap[c.c.grp]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
-            </div>
-        </div>
-        <table>
-            <thead><tr><td>Insurance</td><td>Total</td></tr></thead>
-            <tbody>
-                <tr>
-                    <td>{{fCrd(ship.totalCost * insurance.current.pct)}} <u>CR</u></td>
-                    <td>{{fCrd(ship.totalCost)}} <u>CR</u></td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-
-    <div class="list l" id="jumpRange">
-        <div class="header">Jump Range</div>
-        <div class="cen">
-            <div class="chart" area-chart config="jrChart" series="jrSeries"></div>
-            <div slider max="ship.fuelCapacity" unit="'T'" on-change="::fuelChange(val)" style="position:relative; margin: 0 auto;">
-                <svg class="icon xl primary-disabled" style="position:absolute;height: 100%;"><use xlink:href="#fuel"></use></svg>
-            </div>
-        </div>
-    </div>
+  </div>
 
 </div>

--- a/app/views/page-outfit.html
+++ b/app/views/page-outfit.html
@@ -227,16 +227,6 @@
         </table>
     </div>
 
-    <div class="list l" style="width: 50%;padding: 0 0.5em;">
-        <div class="header">Jump Range</div>
-        <div class="cen">
-            <div class="chart" area-chart config="jrChart" series="jrSeries"></div>
-            <div slider max="ship.fuelCapacity" unit="'T'" on-change="::fuelChange(val)" style="position:relative; margin: 0 auto;">
-                <svg class="icon xl primary-disabled" style="position:absolute;height: 100%;"><use xlink:href="#fuel"></use></svg>
-            </div>
-        </div>
-    </div>
-
     <div class="list r">
         <div class="header">Costs</div>
         <div class="items">
@@ -265,6 +255,16 @@
                 </tr>
             </tbody>
         </table>
+    </div>
+
+    <div class="list l" id="jumpRange">
+        <div class="header">Jump Range</div>
+        <div class="cen">
+            <div class="chart" area-chart config="jrChart" series="jrSeries"></div>
+            <div slider max="ship.fuelCapacity" unit="'T'" on-change="::fuelChange(val)" style="position:relative; margin: 0 auto;">
+                <svg class="icon xl primary-disabled" style="position:absolute;height: 100%;"><use xlink:href="#fuel"></use></svg>
+            </div>
+        </div>
     </div>
 
 </div>

--- a/app/views/page-outfit.html
+++ b/app/views/page-outfit.html
@@ -1,257 +1,270 @@
 <div id="outfit">
 
-  <div id="overview">
-  <h1 ng-bind="ship.name"></h1>
-    <div id="build">
-      <input ng-model="buildName" ng-change="bnChange()" placeholder="Enter Build Name" maxlength="50" />
-      <button ng-click="saveBuild()" ng-disabled="!buildName || savedCode && code == savedCode || !canSave">
-        <svg class="icon lg "><use xlink:href="#floppy-disk"></use></svg> Save
-      </button>
-      <button ng-click="reloadBuild()" ng-disabled="!savedCode || code == savedCode">
-        <svg class="icon lg"><use xlink:href="#spinner11"></use></svg> Reload
-      </button>
-      <button class="danger" ng-click="deleteBuild()" ng-disabled="!savedCode">
-        <svg class="icon lg"><use xlink:href="#bin"></use></svg>
-      </button>
-      <button ui-sref="outfit({shipId: ship.id,code:null, bn: buildName})" ng-disabled="!code">
-        <svg class="icon lg"><use xlink:href="#switch"></use></svg> Reset
-      </button>
-    </div>
-  </div>
-
-  <table id="summary">
-    <thead>
-      <tr class="main">
-        <th rowspan="2">Size</th>
-        <th colspan="3">Maneouverability</th>
-        <th colspan="2">Mass</th>
-        <th rowspan="2">Cargo</th>
-        <th rowspan="2">Fuel</th>
-        <th rowspan="2">Armour</th>
-        <th rowspan="2">Shields</th>
-        <th colspan="2">Power</th>
-        <th colspan="2">Jump Range</th>
-      </tr>
-      <tr>
-        <th>Agility</th><th>Speed</th><th>Boost</th>
-        <th class="lft">Unladen</th><th>Laden</th>
-        <th class="lft">Retracted</th><th>Deployed</th>
-        <th class="lft">Unladen</th><th>Laden</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td ng-bind="SZ[ship.class]"></td>
-        <td>{{ship.agility}}/10</td>
-        <td>{{fRound(ship.speed)}} <u>m/s</u></td>
-        <td>{{fRound(ship.boost)}} <u>m/s</u></td>
-        <td>{{fRound(ship.unladenMass)}} <u>T</u></td>
-        <td>{{fRound(ship.ladenMass)}} <u>T</u></td>
-        <td>{{fRound(ship.cargoCapacity)}} <u>T</u></td>
-        <td>{{fRound(ship.fuelCapacity)}} <u>T</u></td>
-        <td>{{ship.armourTotal}} <span ng-if="ship.armourAdded">({{ship.armour}} + {{ship.armourAdded}})</span></td>
-        <td>{{fRound(ship.shieldStrength)}} <u>Mj</u> <span ng-if="ship.shieldMultiplier > 1">({{fRPct(ship.shieldMultiplier)}})</span></td>
-        <td>{{fPwr(ship.powerRetracted)}} <u>MW ({{fPct(ship.powerRetracted/ship.powerAvailable)}})</u></td>
-        <td>{{fPwr(ship.powerDeployed)}} <u>MW ({{fPct(ship.powerDeployed/ship.powerAvailable)}})</u></td>
-        <td>{{fRound(ship.unladenJumpRange)}} <u>LY</u></td>
-        <td>{{fRound(ship.ladenJumpRange)}} <u>LY</u></td>
-      </tr>
-    </tbody>
-  </table>
-
-  <div id="standard" class="slot-group l">
-    <h1>Standard</h1>
-    <div class="slot" ng-click="selectSlot($event, ship.bulkheads)" ng-class="{selected: selectedSlot==ship.bulkheads}">
-      <div class="details">
-        <div class="sz"><span>8</span></div>
-        <div class="l">Bulkheads</div>
-        <div class="r">{{ship.bulkheads.c.mass}} <u>T</u></div>
-        <div class="cl l">{{ship.bulkheads.c.name}}</div>
-      </div>
-      <div class="select" ng-if="selectedSlot==ship.bulkheads" ng-click="select('b',ship.bulkheads,$event)"><ul>
-        <li class="lc" ng-class="{active: ship.bulkheads.id=='0'}" cpid="0">Lightweight Alloy</li>
-        <li class="lc" ng-class="{active: ship.bulkheads.id=='1'}" cpid="1">Reinforced Alloy</li>
-        <li class="lc" ng-class="{active: ship.bulkheads.id=='2'}" cpid="2">Military Grade Composite</li>
-        <li class="lc" ng-class="{active: ship.bulkheads.id=='3'}" cpid="3">Mirrored Surface Composite</li>
-        <li class="lc" ng-class="{active: ship.bulkheads.id=='4'}" cpid="4">Reactive Surface Composite</li>
-      </ul></div>
-    </div>
-    <div class="slot" ng-click="selectSlot($event, pp)" ng-class="{selected: selectedSlot==pp}">
-      <div class="details">
-        <div class="sz">{{::pp.maxClass}}</div>
-        <div class="l">{{pp.id}} Power Plant</div>
-        <div class="r">{{pp.c.mass}} <u>T</u></div>
-        <div class="cb"></div>
-        <div class="l">Efficiency: {{pp.c.eff}}</div>
-        <div class="l">Power: {{pp.c.pGen}} <u>MW</u></div>
-      </div>
-      <div component-select class="select" s="pp" opts="availCS.common[0]" ng-if="selectedSlot==pp" ng-click="select('c',pp,$event)"></div>
-    </div>
-    <div class="slot" ng-click="selectSlot($event, th)" ng-class="{selected: selectedSlot==th}">
-      <div class="details">
-        <div class="sz">{{::th.maxClass}}</div>
-        <div class="l">{{th.id}} Thrusters</div>
-        <div class="r">{{th.c.mass}} <u>T</u></div>
-        <div class="cb"></div>
-        <div class="l">Opt: {{th.c.optmass}} <u>T</u></div>
-        <div class="l">Max: {{th.c.maxmass}} <u>T</u></div>
-      </div>
-      <div component-select class="select" s="th" mass="ship.unladenMass" opts="availCS.common[1]" ng-if="selectedSlot==th" ng-click="select('c',th,$event)"></div>
-    </div>
-    <div class="slot" ng-click="selectSlot($event, fsd)" ng-class="{selected: selectedSlot==fsd}">
-      <div class="details">
-        <div class="sz">{{::fsd.maxClass}}</div>
-        <div class="l">{{fsd.id}} Frame Shift Drive</div>
-        <div class="r cr">{{fsd.c.mass}} <u>T</u></div>
-        <div class="cb"></div>
-        <div class="l">Opt: {{fsd.c.optmass}} <u>T</u></div>
-        <div class="l">Max Fuel: {{fsd.c.maxfuel}} <u>T</u></div>
-      </div>
-      <div component-select class="select" s="fsd" opts="availCS.common[2]" ng-if="selectedSlot==fsd" ng-click="select('c',fsd,$event)"></div>
-    </div>
-    <div class="slot" ng-click="selectSlot($event, ls)" ng-class="{selected: selectedSlot==ls}">
-      <div class="details">
-        <div class="sz">{{::ls.maxClass}}</div>
-        <div class="l">{{ls.id}} Life Support</div>
-        <div class="r">{{ls.c.mass}} <u>T</u></div>
-        <div class="cb"></div>
-        <div class="l">Time: {{fTime(ls.c.time)}}</div>
-      </div>
-      <div component-select class="select" s="ls" opts="availCS.common[3]" ng-if="selectedSlot==ls" ng-click="select('c',ls,$event)"></div>
-    </div>
-    <div class="slot" ng-click="selectSlot($event, pd)" ng-class="{selected: selectedSlot==pd}">
-      <div class="details">
-        <div class="sz">{{::pd.maxClass}}</div>
-        <div class="l">{{pd.id}} Power Distributor</div>
-        <div class="r">{{pd.c.mass}} <u>T</u></div>
-        <div class="cb"></div>
-        <div class="l">Wep: {{pd.c.weaponcapacity}} <u>Mj</u> / {{pd.c.weaponrecharge}} <u>MW</u></div>
-        <div class="l">Sys: {{pd.c.systemcapacity}} <u>Mj</u> / {{pd.c.systemrecharge}} <u>MW</u></div>
-        <div class="l">Eng: {{pd.c.enginecapacity}} <u>Mj</u> / {{pd.c.enginerecharge}} <u>MW</u></div>
-      </div>
-      <div component-select class="select" s="pd" opts="availCS.common[4]" ng-if="selectedSlot==pd" ng-click="select('c',pd,$event)"></div>
-    </div>
-    <div class="slot" ng-click="selectSlot($event, ss)" ng-class="{selected: selectedSlot==ss}">
-      <div class="details">
-        <div class="sz">{{::ss.maxClass}}</div>
-        <div class="l">{{ss.id}} Sensors</div>
-        <div class="r">{{ss.c.mass}} <u>T</u></div>
-        <div class="cb"></div>
-        <div class="l">{{ss.c.range}} <u>KM</u></div>
-      </div>
-      <div component-select class="select" s="ss" opts="availCS.common[5]" ng-if="selectedSlot==ss" ng-click="select('c',ss,$event)"></div>
-    </div>
-    <div class="slot" ng-click="selectSlot($event, ft)" ng-class="{selected: selectedSlot==ft}">
-      <div class="details">
-        <div class="sz">{{::ft.maxClass}}</div>
-        <div class="l">{{ft.id}} Fuel Tank</div>
-        <div class="r">{{ft.c.capacity}} <u>T</u></div>
-      </div>
-      <div component-select class="select" s="ft" opts="availCS.common[6]" ng-if="selectedSlot==ft" ng-click="select('c',ft,$event)"></div>
-    </div>
-  </div>
-
-  <div id="hardpoints" class="slot-group l">
-    <h1>HardPoints</h1>
-    <div class="slot" ng-repeat="h in ship.hardpoints | filter:{maxClass: '!0'}" ng-click="selectSlot($event, h)" ng-class="{selected: selectedSlot==h}">
-      <div slot-hardpoint class="details" hp="h" size="HPC[h.maxClass]" lbl="hgMap[h.c.grp]"></div>
-      <div class="select" ng-class="{hardpoint: h.maxClass > 0}" ng-if="selectedSlot==h" ng-click="select('h',h,$event)">
-        <div component-select s="h" groups="availCS.getHps(h.maxClass)"></div>
-      </div>
-    </div>
-  </div>
-
-  <div id="utility" class="slot-group l">
-    <h1>Utility Mounts</h1>
-    <div class="slot" ng-repeat="h in ship.hardpoints | filter:{maxClass: '0'}" ng-click="selectSlot($event, h)" ng-class="{selected: selectedSlot==h}">
-      <div slot-hardpoint class="details" hp="h" size="HPC[h.maxClass]" lbl="hgMap[h.c.grp]"></div>
-      <div class="select" ng-class="{hardpoint: h.maxClass > 0}" ng-if="selectedSlot==h" ng-click="select('h',h,$event)">
-        <div component-select s="h" groups="availCS.getHps(h.maxClass)"></div>
-      </div>
-    </div>
-  </div>
-
-  <div id="internal" class="slot-group r">
-    <h1>Internal Compartments</h1>
-    <div class="slot" ng-repeat="i in ship.internal" ng-click="selectSlot($event, i)" ng-class="{selected: selectedSlot==i}">
-      <div slot-internal class="details" slot="i" lbl="igMap[i.c.grp]" ft="ft"></div>
-      <div class="select" ng-if="selectedSlot==i" ng-click="select('i',i,$event)">
-        <div component-select s="i" groups="availCS.getInts(i.maxClass)"></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="cb"></div>
-
-  <div class="list l">
-    <div class="header">Power Use</div>
-    <div class="items">
-    <div class="primary-disabled">Generated</div>
-      <div ng-if="pp.c.pGen" class="item common enabled untoggleable">
-        <div class="lbl">{{pp.c.class}}{{pp.c.rating}} Power Plant</div><div class="val">{{fPwr(pp.c.pGen)}}</div>
-      </div>
-      <div class="primary-disabled">Standard</div>
-      <div ng-repeat="c in ship.common" ng-if="c.c.power" class="item common" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
-        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{CArr[$index]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
-      </div>
-      <div class="item common consumer" ng-class="{enabled:ship.cargoScoop.enabled}" ng-click="togglePwr(ship.cargoScoop)">
-        <div class="lbl">1H Cargo Scoop</div><div class="val">{{fPwr(ship.cargoScoop.c.power)}}</div>
-      </div>
-      <div class="primary-disabled">Hardpoints</div>
-      <div ng-repeat="c in ship.hardpoints" ng-if="c.c.power" class="item hardpoints" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
-        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || hgMap[c.c.grp]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
-      </div>
-      <div class="primary-disabled">Internal</div>
-      <div ng-repeat="c in ship.internal" ng-if="c.c.power" class="item internal" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
-        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || igMap[c.c.grp]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
-      </div>
+    <div id="overview">
+        <h1 ng-bind="ship.name"></h1>
+        <div id="build">
+            <input ng-model="buildName" ng-change="bnChange()" placeholder="Enter Build Name" maxlength="50" />
+            <button ng-click="saveBuild()" ng-disabled="!buildName || savedCode && code == savedCode || !canSave">
+                <svg class="icon lg "><use xlink:href="#floppy-disk"></use></svg><span class="outfit-button-label">Save</span>
+            </button>
+            <button ng-click="reloadBuild()" ng-disabled="!savedCode || code == savedCode">
+                <svg class="icon lg"><use xlink:href="#spinner11"></use></svg><span class="outfit-button-label">Reload</span>
+            </button>
+            <button class="danger" ng-click="deleteBuild()" ng-disabled="!savedCode">
+                <svg class="icon lg"><use xlink:href="#bin"></use></svg>
+            </button>
+            <button ui-sref="outfit({shipId: ship.id,code:null, bn: buildName})" ng-disabled="!code">
+                <svg class="icon lg"><use xlink:href="#switch"></use></svg><span class="outfit-button-label">Reset</span>
+            </button>
+        </div>
     </div>
 
-    <table>
-      <thead><tr><td>Retracted</td><td>Deployed</td></tr></thead>
-      <tbody><tr>
-        <td>{{fPwr(ship.powerRetracted)}} <u>MW</u> ({{fPct(ship.powerRetracted/ship.powerAvailable)}})</td>
-        <td>{{fPwr(ship.powerDeployed)}} <u>MW</u> ({{fPct(ship.powerDeployed/ship.powerAvailable)}})</td>
-      </tr></tbody>
-    </table>
-  </div>
-
-  <div class="list l" style="width: 50%;padding: 0 0.5em;">
-    <div class="header">Jump Range</div>
-    <div class="cen">
-      <div class="chart" area-chart config="jrChart" series="jrSeries"></div>
-      <div slider max="ship.fuelCapacity" unit="'T'" on-change="::fuelChange(val)" style="position:relative; margin: 0 auto;">
-        <svg class="icon xl primary-disabled" style="position:absolute;height: 100%;"><use xlink:href="#fuel"></use></svg>
-      </div>
+    <div id="summary">
+        <table id="summaryTable">
+            <thead>
+                <tr class="main">
+                    <th rowspan="2">Size</th>
+                    <th colspan="3">Maneouverability</th>
+                    <th colspan="2">Mass</th>
+                    <th rowspan="2">Cargo</th>
+                    <th rowspan="2">Fuel</th>
+                    <th rowspan="2">Armour</th>
+                    <th rowspan="2">Shields</th>
+                    <th colspan="2">Power</th>
+                    <th colspan="2">Jump Range</th>
+                </tr>
+                <tr>
+                    <th>Agility</th>
+                    <th>Speed</th>
+                    <th>Boost</th>
+                    <th class="lft">Unladen</th>
+                    <th>Laden</th>
+                    <th class="lft">Retracted</th>
+                    <th>Deployed</th>
+                    <th class="lft">Unladen</th>
+                    <th>Laden</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td ng-bind="SZ[ship.class]"></td>
+                    <td>{{ship.agility}}/10</td>
+                    <td>{{fRound(ship.speed)}} <u>m/s</u></td>
+                    <td>{{fRound(ship.boost)}} <u>m/s</u></td>
+                    <td>{{fRound(ship.unladenMass)}} <u>T</u></td>
+                    <td>{{fRound(ship.ladenMass)}} <u>T</u></td>
+                    <td>{{fRound(ship.cargoCapacity)}} <u>T</u></td>
+                    <td>{{fRound(ship.fuelCapacity)}} <u>T</u></td>
+                    <td>{{ship.armourTotal}} <span ng-if="ship.armourAdded">({{ship.armour}} + {{ship.armourAdded}})</span></td>
+                    <td>{{fRound(ship.shieldStrength)}} <u>Mj</u> <span ng-if="ship.shieldMultiplier > 1">({{fRPct(ship.shieldMultiplier)}})</span></td>
+                    <td>{{fPwr(ship.powerRetracted)}} <u>MW ({{fPct(ship.powerRetracted/ship.powerAvailable)}})</u></td>
+                    <td>{{fPwr(ship.powerDeployed)}} <u>MW ({{fPct(ship.powerDeployed/ship.powerAvailable)}})</u></td>
+                    <td>{{fRound(ship.unladenJumpRange)}} <u>LY</u></td>
+                    <td>{{fRound(ship.ladenJumpRange)}} <u>LY</u></td>
+                </tr>
+            </tbody>
+        </table>
     </div>
-  </div>
 
-  <div class="list r">
-    <div class="header">Costs</div>
-    <div class="items">
-      <div class="item" ng-class="{enabled:ship.incCost}" ng-click="toggleCost(ship)">
-        <div class="lbl">{{ship.name}}</div><div class="val">{{fCrd(ship.cost)}}</div>
-      </div>
-      <div class="item" ng-class="{enabled:ship.bulkheads.incCost}" ng-click="toggleCost(ship.bulkheads)" ng-if="ship.bulkheads.c.cost">
-        <div class="lbl">{{ship.bulkheads.c.name}}</div><div class="val">{{fCrd(ship.bulkheads.c.cost)}}</div>
-      </div>
-      <div ng-repeat="c in ship.common" ng-if="c.c.cost" class="item common" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
-        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{CArr[$index]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
-      </div>
-      <div ng-repeat="c in ship.hardpoints" ng-if="c.c.cost" class="item hardpoints" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
-        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || hgMap[c.c.grp]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
-      </div>
-      <div ng-repeat="c in ship.internal" ng-if="c.c.cost" class="item internal" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
-        <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || igMap[c.c.grp]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
-      </div>
+    <div id="standard" class="slot-group l">
+        <h1>Standard</h1>
+        <div class="slot" ng-click="selectSlot($event, ship.bulkheads)" ng-class="{selected: selectedSlot==ship.bulkheads}">
+            <div class="details">
+                <div class="sz"><span>8</span></div>
+                <div class="l">Bulkheads</div>
+                <div class="r">{{ship.bulkheads.c.mass}} <u>T</u></div>
+                <div class="cl l">{{ship.bulkheads.c.name}}</div>
+            </div>
+            <div class="select" ng-if="selectedSlot==ship.bulkheads" ng-click="select('b',ship.bulkheads,$event)">
+                <ul>
+                    <li class="lc" ng-class="{active: ship.bulkheads.id=='0'}" cpid="0">Lightweight Alloy</li>
+                    <li class="lc" ng-class="{active: ship.bulkheads.id=='1'}" cpid="1">Reinforced Alloy</li>
+                    <li class="lc" ng-class="{active: ship.bulkheads.id=='2'}" cpid="2">Military Grade Composite</li>
+                    <li class="lc" ng-class="{active: ship.bulkheads.id=='3'}" cpid="3">Mirrored Surface Composite</li>
+                    <li class="lc" ng-class="{active: ship.bulkheads.id=='4'}" cpid="4">Reactive Surface Composite</li>
+                </ul>
+            </div>
+        </div>
+        <div class="slot" ng-click="selectSlot($event, pp)" ng-class="{selected: selectedSlot==pp}">
+            <div class="details">
+                <div class="sz">{{::pp.maxClass}}</div>
+                <div class="l">{{pp.id}} Power Plant</div>
+                <div class="r">{{pp.c.mass}} <u>T</u></div>
+                <div class="cb"></div>
+                <div class="l">Efficiency: {{pp.c.eff}}</div>
+                <div class="l">Power: {{pp.c.pGen}} <u>MW</u></div>
+            </div>
+            <div component-select class="select" s="pp" opts="availCS.common[0]" ng-if="selectedSlot==pp" ng-click="select('c',pp,$event)"></div>
+        </div>
+        <div class="slot" ng-click="selectSlot($event, th)" ng-class="{selected: selectedSlot==th}">
+            <div class="details">
+                <div class="sz">{{::th.maxClass}}</div>
+                <div class="l">{{th.id}} Thrusters</div>
+                <div class="r">{{th.c.mass}} <u>T</u></div>
+                <div class="cb"></div>
+                <div class="l">Opt: {{th.c.optmass}} <u>T</u></div>
+                <div class="l">Max: {{th.c.maxmass}} <u>T</u></div>
+            </div>
+            <div component-select class="select" s="th" mass="ship.unladenMass" opts="availCS.common[1]" ng-if="selectedSlot==th" ng-click="select('c',th,$event)"></div>
+        </div>
+        <div class="slot" ng-click="selectSlot($event, fsd)" ng-class="{selected: selectedSlot==fsd}">
+            <div class="details">
+                <div class="sz">{{::fsd.maxClass}}</div>
+                <div class="l">{{fsd.id}} Frame Shift Drive</div>
+                <div class="r cr">{{fsd.c.mass}} <u>T</u></div>
+                <div class="cb"></div>
+                <div class="l">Opt: {{fsd.c.optmass}} <u>T</u></div>
+                <div class="l">Max Fuel: {{fsd.c.maxfuel}} <u>T</u></div>
+            </div>
+            <div component-select class="select" s="fsd" opts="availCS.common[2]" ng-if="selectedSlot==fsd" ng-click="select('c',fsd,$event)"></div>
+        </div>
+        <div class="slot" ng-click="selectSlot($event, ls)" ng-class="{selected: selectedSlot==ls}">
+            <div class="details">
+                <div class="sz">{{::ls.maxClass}}</div>
+                <div class="l">{{ls.id}} Life Support</div>
+                <div class="r">{{ls.c.mass}} <u>T</u></div>
+                <div class="cb"></div>
+                <div class="l">Time: {{fTime(ls.c.time)}}</div>
+            </div>
+            <div component-select class="select" s="ls" opts="availCS.common[3]" ng-if="selectedSlot==ls" ng-click="select('c',ls,$event)"></div>
+        </div>
+        <div class="slot" ng-click="selectSlot($event, pd)" ng-class="{selected: selectedSlot==pd}">
+            <div class="details">
+                <div class="sz">{{::pd.maxClass}}</div>
+                <div class="l">{{pd.id}} Power Distributor</div>
+                <div class="r">{{pd.c.mass}} <u>T</u></div>
+                <div class="cb"></div>
+                <div class="l">Wep: {{pd.c.weaponcapacity}} <u>Mj</u> / {{pd.c.weaponrecharge}} <u>MW</u></div>
+                <div class="l">Sys: {{pd.c.systemcapacity}} <u>Mj</u> / {{pd.c.systemrecharge}} <u>MW</u></div>
+                <div class="l">Eng: {{pd.c.enginecapacity}} <u>Mj</u> / {{pd.c.enginerecharge}} <u>MW</u></div>
+            </div>
+            <div component-select class="select" s="pd" opts="availCS.common[4]" ng-if="selectedSlot==pd" ng-click="select('c',pd,$event)"></div>
+        </div>
+        <div class="slot" ng-click="selectSlot($event, ss)" ng-class="{selected: selectedSlot==ss}">
+            <div class="details">
+                <div class="sz">{{::ss.maxClass}}</div>
+                <div class="l">{{ss.id}} Sensors</div>
+                <div class="r">{{ss.c.mass}} <u>T</u></div>
+                <div class="cb"></div>
+                <div class="l">{{ss.c.range}} <u>KM</u></div>
+            </div>
+            <div component-select class="select" s="ss" opts="availCS.common[5]" ng-if="selectedSlot==ss" ng-click="select('c',ss,$event)"></div>
+        </div>
+        <div class="slot" ng-click="selectSlot($event, ft)" ng-class="{selected: selectedSlot==ft}">
+            <div class="details">
+                <div class="sz">{{::ft.maxClass}}</div>
+                <div class="l">{{ft.id}} Fuel Tank</div>
+                <div class="r">{{ft.c.capacity}} <u>T</u></div>
+            </div>
+            <div component-select class="select" s="ft" opts="availCS.common[6]" ng-if="selectedSlot==ft" ng-click="select('c',ft,$event)"></div>
+        </div>
     </div>
-    <table>
-      <thead><tr><td>Insurance</td><td>Total</td></tr></thead>
-      <tbody><tr>
-        <td>{{fCrd(ship.totalCost * insurance.current.pct)}} <u>CR</u></td>
-        <td>{{fCrd(ship.totalCost)}} <u>CR</u></td>
-      </tr></tbody>
-    </table>
-  </div>
+
+    <div id="hardpoints" class="slot-group l">
+        <h1>HardPoints</h1>
+        <div class="slot" ng-repeat="h in ship.hardpoints | filter:{maxClass: '!0'}" ng-click="selectSlot($event, h)" ng-class="{selected: selectedSlot==h}">
+            <div slot-hardpoint class="details" hp="h" size="HPC[h.maxClass]" lbl="hgMap[h.c.grp]"></div>
+            <div class="select" ng-class="{hardpoint: h.maxClass > 0}" ng-if="selectedSlot==h" ng-click="select('h',h,$event)">
+                <div component-select s="h" groups="availCS.getHps(h.maxClass)"></div>
+            </div>
+        </div>
+    </div>
+
+    <div id="utility" class="slot-group l">
+        <h1>Utility Mounts</h1>
+        <div class="slot" ng-repeat="h in ship.hardpoints | filter:{maxClass: '0'}" ng-click="selectSlot($event, h)" ng-class="{selected: selectedSlot==h}">
+            <div slot-hardpoint class="details" hp="h" size="HPC[h.maxClass]" lbl="hgMap[h.c.grp]"></div>
+            <div class="select" ng-class="{hardpoint: h.maxClass > 0}" ng-if="selectedSlot==h" ng-click="select('h',h,$event)">
+                <div component-select s="h" groups="availCS.getHps(h.maxClass)"></div>
+            </div>
+        </div>
+    </div>
+
+    <div id="internal" class="slot-group r">
+        <h1>Internal Compartments</h1>
+        <div class="slot" ng-repeat="i in ship.internal" ng-click="selectSlot($event, i)" ng-class="{selected: selectedSlot==i}">
+            <div slot-internal class="details" slot="i" lbl="igMap[i.c.grp]" ft="ft"></div>
+            <div class="select" ng-if="selectedSlot==i" ng-click="select('i',i,$event)">
+                <div component-select s="i" groups="availCS.getInts(i.maxClass)"></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="cb"></div>
+
+    <div class="list l">
+        <div class="header">Power Use</div>
+        <div class="items">
+            <div class="primary-disabled">Generated</div>
+            <div ng-if="pp.c.pGen" class="item common enabled untoggleable">
+                <div class="lbl">{{pp.c.class}}{{pp.c.rating}} Power Plant</div><div class="val">{{fPwr(pp.c.pGen)}}</div>
+            </div>
+            <div class="primary-disabled">Standard</div>
+            <div ng-repeat="c in ship.common" ng-if="c.c.power" class="item common" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
+                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{CArr[$index]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
+            </div>
+            <div class="item common consumer" ng-class="{enabled:ship.cargoScoop.enabled}" ng-click="togglePwr(ship.cargoScoop)">
+                <div class="lbl">1H Cargo Scoop</div><div class="val">{{fPwr(ship.cargoScoop.c.power)}}</div>
+            </div>
+            <div class="primary-disabled">Hardpoints</div>
+            <div ng-repeat="c in ship.hardpoints" ng-if="c.c.power" class="item hardpoints" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
+                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || hgMap[c.c.grp]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
+            </div>
+            <div class="primary-disabled">Internal</div>
+            <div ng-repeat="c in ship.internal" ng-if="c.c.power" class="item internal" ng-class="{enabled:c.enabled, consumer:c.c.power}" ng-click="togglePwr(c)">
+                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || igMap[c.c.grp]}}</div><div class="val">{{fPwr(c.c.power)}}</div>
+            </div>
+        </div>
+
+        <table>
+            <thead><tr><td>Retracted</td><td>Deployed</td></tr></thead>
+            <tbody>
+                <tr>
+                    <td>{{fPwr(ship.powerRetracted)}} <u>MW</u> ({{fPct(ship.powerRetracted/ship.powerAvailable)}})</td>
+                    <td>{{fPwr(ship.powerDeployed)}} <u>MW</u> ({{fPct(ship.powerDeployed/ship.powerAvailable)}})</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="list l" style="width: 50%;padding: 0 0.5em;">
+        <div class="header">Jump Range</div>
+        <div class="cen">
+            <div class="chart" area-chart config="jrChart" series="jrSeries"></div>
+            <div slider max="ship.fuelCapacity" unit="'T'" on-change="::fuelChange(val)" style="position:relative; margin: 0 auto;">
+                <svg class="icon xl primary-disabled" style="position:absolute;height: 100%;"><use xlink:href="#fuel"></use></svg>
+            </div>
+        </div>
+    </div>
+
+    <div class="list r">
+        <div class="header">Costs</div>
+        <div class="items">
+            <div class="item" ng-class="{enabled:ship.incCost}" ng-click="toggleCost(ship)">
+                <div class="lbl">{{ship.name}}</div><div class="val">{{fCrd(ship.cost)}}</div>
+            </div>
+            <div class="item" ng-class="{enabled:ship.bulkheads.incCost}" ng-click="toggleCost(ship.bulkheads)" ng-if="ship.bulkheads.c.cost">
+                <div class="lbl">{{ship.bulkheads.c.name}}</div><div class="val">{{fCrd(ship.bulkheads.c.cost)}}</div>
+            </div>
+            <div ng-repeat="c in ship.common" ng-if="c.c.cost" class="item common" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
+                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{CArr[$index]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
+            </div>
+            <div ng-repeat="c in ship.hardpoints" ng-if="c.c.cost" class="item hardpoints" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
+                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || hgMap[c.c.grp]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
+            </div>
+            <div ng-repeat="c in ship.internal" ng-if="c.c.cost" class="item internal" ng-class="{enabled:c.incCost}" ng-click="toggleCost(c)">
+                <div class="lbl">{{c.c.class}}{{c.c.rating}} {{c.c.name || igMap[c.c.grp]}}</div><div class="val">{{fCrd(c.c.cost)}}</div>
+            </div>
+        </div>
+        <table>
+            <thead><tr><td>Insurance</td><td>Total</td></tr></thead>
+            <tbody>
+                <tr>
+                    <td>{{fCrd(ship.totalCost * insurance.current.pct)}} <u>CR</u></td>
+                    <td>{{fCrd(ship.totalCost)}} <u>CR</u></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
 </div>


### PR DESCRIPTION
I've responsived up the outfitting screen and fixed a small issue on really old iPhones on the ship selection screen.

Everything on the outfitting screen should look ok now on desktops down on to the original iPhone.

One thing I didn't change was the summary table, I started, but ended up putting those changes in a separate branch so I can work on them some more. For now, that table becomes scrollable horizontally on smaller devices (once it can't shrink down anymore). It's not ideal, but it's better than before at least :).
