### PR TITLE
Fix for Build DDL missing builds #48

### DIFF
--- a/app/less/header.less
+++ b/app/less/header.less
@@ -77,7 +77,7 @@ header {
     overflow-y: auto;
     z-index: 0;
     -webkit-overflow-scrolling: touch;
-    max-height: 400px;
+    max-height: 600px;
 
     .tablet({
       font-size: 1.1em;


### PR DESCRIPTION
Increased the max-height of the Builds drop-down to more builds will fit in the list (previously couple of each ship would mean Viper and Vulture builds wouldn't be in the list).
