### PR TITLE
Adding powerplant capacity warnings

### DIFF
--- a/app/js/controllers/controller-outfit.js
+++ b/app/js/controllers/controller-outfit.js
@@ -392,6 +392,10 @@ angular.module('app').controller('OutfitController', ['$window', '$rootScope', '
     $scope.costTab = tab;
   };
 
+  $scope.ppWarning = function(pp) {
+    return pp.pGen < ship.powerRetracted;
+  }
+
   $scope.pdWarning = function(pd) {
     return pd.enginecapacity < ship.boostEnergy;
   };

--- a/app/js/controllers/controller-outfit.js
+++ b/app/js/controllers/controller-outfit.js
@@ -394,7 +394,7 @@ angular.module('app').controller('OutfitController', ['$window', '$rootScope', '
 
   $scope.ppWarning = function(pp) {
     return pp.pGen < ship.powerRetracted;
-  }
+  };
 
   $scope.pdWarning = function(pd) {
     return pd.enginecapacity < ship.boostEnergy;

--- a/app/views/page-outfit.html
+++ b/app/views/page-outfit.html
@@ -111,7 +111,7 @@
       </div>
     </div>
     <div class="slot" ng-click="selectSlot($event, pp)" ng-class="{selected: selectedSlot==pp}">
-      <div class="details">
+      <div class="details" ng-class="{warning: pp.c.pGen < ship.powerRetracted}">
         <div class="sz">{{::pp.maxClass}}</div>
         <div class="l">{{pp.id}} Power Plant</div>
         <div class="r">{{pp.c.mass}} <u>T</u></div>
@@ -119,7 +119,7 @@
         <div class="l">Efficiency: {{pp.c.eff}}</div>
         <div class="l">Power: {{pp.c.pGen}} <u>MW</u></div>
       </div>
-      <div component-select class="select" s="pp" opts="availCS.common[0]" ng-if="selectedSlot==pp" ng-click="select('c',pp,$event)"></div>
+      <div component-select class="select" s="pp" warning="ppWarning" opts="availCS.common[0]" ng-if="selectedSlot==pp" ng-click="select('c',pp,$event)"></div>
     </div>
     <div class="slot" ng-click="selectSlot($event, th)" ng-class="{selected: selectedSlot==th}">
       <div class="details">


### PR DESCRIPTION
Extended power distributor component selection functionality to warn when modules would be disabled in retracted state based on selected power management scheme.

Also changed priority 1 display in power bands to turn gray if it exceeds 40% powerplant output resulting in all modules going offline if powerplant malfunctions. Numeric label for priority 1 changes to message about modules disabled during malfunction state for most sane display resolutions.
