### PR TITLE
Additional refinement to "Optimize Mass" preset

### DIFF
--- a/app/js/controllers/controller-outfit.js
+++ b/app/js/controllers/controller-outfit.js
@@ -211,13 +211,14 @@ angular.module('app').controller('OutfitController', ['$window', '$rootScope', '
     ship.hardpoints.forEach(function(slot) { ship.use(slot, null, null); });
     ship.internal.forEach(function(slot) { ship.use(slot, null, null); });
     ship.useBulkhead(0);
-    ship.use(common[1], common[1].maxClass + 'D', Components.common(1, common[1].maxClass + 'D')); // Thrusters
     ship.use(common[2], common[2].maxClass + 'A', Components.common(2, common[2].maxClass + 'A')); // FSD
     ship.use(common[3], common[3].maxClass + 'D', Components.common(3, common[3].maxClass + 'D')); // Life Support
     ship.use(common[5], common[5].maxClass + 'D', Components.common(5, common[5].maxClass + 'D')); // Sensors
 
     var pd = $scope.availCS.lightestPowerDist(ship.boostEnergy); // Find lightest Power Distributor that can still boost
     ship.use(ship.common[4], pd, Components.common(4, pd));
+    var th = $scope.availCS.lightestThruster(ship.ladenMass); // Find lightest Thruster that still works for the ship at max mass
+    ship.use(ship.common[1], th, Components.common(1, th));
     var pp = $scope.availCS.lightestPowerPlant(ship.powerRetracted); // Find lightest Power plant that can power the ship
     ship.use(ship.common[0], pp, Components.common(0, pp));
 

--- a/app/js/shipyard/factory-component-set.js
+++ b/app/js/shipyard/factory-component-set.js
@@ -105,6 +105,18 @@ angular.module('shipyard').factory('ComponentSet', ['lodash', function(_) {
     return pd.class + pd.rating;
   };
 
+  ComponentSet.prototype.lightestThruster = function(ladenMass) {
+    var ths = this.common[1];
+    var th = ths[0];
+
+    for (var i = 1; i < ths.length; i++) {
+      if (ths[i].mass < th.mass && ths[i].maxmass >= ladenMass) {
+        th = ths[i];
+      }
+    }
+    return th.class + th.rating;
+  };
+
   ComponentSet.prototype.lightestPowerPlant = function(powerUsed) {
     var pps = this.common[0];
     var pp = null;


### PR DESCRIPTION
Given that the spirit of the Optimize Mass preset seems to be oriented towards explorers because of the A-rated FSD, I've added some similar logic to pick the lowest mass thruster that can still be used.

Substituting maxmass for optmass would be trivial if you think that's better.
