### PR TITLE
Include v1.4-beta ships

### DIFF
--- a/data/components/bulkheads.json
+++ b/data/components/bulkheads.json
@@ -221,6 +221,80 @@
       "mass": 60
     }
   ],
+  "imperial_eagle": [
+    {
+      "name": "Lightweight Alloy",
+      "class": 1,
+      "rating": "I",
+      "cost": 0,
+      "mass": 0
+    },
+    {
+      "name": "Reinforced Alloy",
+      "class": 1,
+      "rating": "I",
+      "cost": 66500,
+      "mass": 4
+    },
+    {
+      "name": "Military Grade Composite",
+      "class": 1,
+      "rating": "I",
+      "cost": 222765,
+      "mass": 8
+    },
+    {
+      "name": "Mirrored Surface Composite",
+      "class": 1,
+      "rating": "I",
+      "cost": 346555,
+      "mass": 8
+    },
+    {
+      "name": "Reactive Surface Composite",
+      "class": 1,
+      "rating": "I",
+      "cost": 372044,
+      "mass": 8
+    }
+  ],
+  "federal_assault_ship": [
+    {
+      "name": "Lightweight Alloy",
+      "class": 1,
+      "rating": "I",
+      "cost": 0,
+      "mass": 0
+    },
+    {
+      "name": "Reinforced Alloy",
+      "class": 1,
+      "rating": "I",
+      "cost": 7925682,
+      "mass": 44
+    },
+    {
+      "name": "Military Grade Composite",
+      "class": 1,
+      "rating": "I",
+      "cost": 17832784,
+      "mass": 87
+    },
+    {
+      "name": "Mirrored Surface Composite",
+      "class": 1,
+      "rating": "I",
+      "cost": 42144814,
+      "mass": 87
+    },
+    {
+      "name": "Reactive Surface Composite",
+      "class": 1,
+      "rating": "I",
+      "cost": 46702081,
+      "mass": 87
+    }
+  ],
   "federal_dropship": [
     {
       "name": "Lightweight Alloy",
@@ -255,6 +329,43 @@
       "class": 1,
       "rating": "I",
       "cost": 46702081,
+      "mass": 87
+    }
+  ],
+  "federal_gunship": [
+    {
+      "name": "Lightweight Alloy",
+      "class": 1,
+      "rating": "I",
+      "cost": 0,
+      "mass": 0
+    },
+    {
+      "name": "Reinforced Alloy",
+      "class": 1,
+      "rating": "I",
+      "cost": 14325688,
+      "mass": 44
+    },
+    {
+      "name": "Military Grade Composite",
+      "class": 1,
+      "rating": "I",
+      "cost": 32232788,
+      "mass": 87
+    },
+    {
+      "name": "Mirrored Surface Composite",
+      "class": 1,
+      "rating": "I",
+      "cost":   76176811,
+      "mass": 87
+    },
+    {
+      "name": "Reactive Surface Composite",
+      "class": 1,
+      "rating": "I",
+      "cost": 84414088,
       "mass": 87
     }
   ],

--- a/data/ships/federal_assault_ship.json
+++ b/data/ships/federal_assault_ship.json
@@ -1,0 +1,77 @@
+{
+  "federal_assault_ship": {
+    "properties": {
+      "name": "Federal Assault Ship",
+      "manufacturer": "Core Dynamics",
+      "class": 2,
+      "hullCost": 19071993,
+      "speed": 216,
+      "boost": 361,
+      "boostEnergy": 21,
+      "agility": 6,
+      "baseShieldStrength": 180,
+      "baseArmour": 540,
+      "hullMass": 480,
+      "masslock": 14
+    },
+    "retailCost": 19814205,
+    "slots": {
+      "common": [
+        6,
+        6,
+        5,
+        5,
+        6,
+        4,
+        4
+      ],
+      "hardpoints": [
+        3,
+        3,
+        2,
+        2,
+        0,
+        0,
+        0,
+        0
+      ],
+      "internal": [
+        5,
+        5,
+        4,
+        3,
+        2,
+        2
+      ]
+    },
+    "defaults": {
+      "common": [
+        "6E",
+        "6E",
+        "5E",
+        "5E",
+        "6E",
+        "4E",
+        "4C"
+      ],
+      "hardpoints": [
+        0,
+        0,
+        17,
+        17,
+        0,
+        0,
+        0,
+        0
+      ],
+      "internal": [
+        "4e",
+        "03",
+        "02",
+        "02",
+        0,
+        0
+      ]
+    }
+  }
+}

--- a/data/ships/federal_gunship.json
+++ b/data/ships/federal_gunship.json
@@ -1,0 +1,81 @@
+{
+  "federal_gunship": {
+    "properties": {
+      "name": "Federal Gunship",
+      "manufacturer": "Core Dynamics",
+      "class": 2,
+      "hullCost": 34774802,
+      "speed": 172,
+      "boost": 284,
+      "boostEnergy": 21,
+      "agility": 2,
+      "baseShieldStrength": 240,
+      "baseArmour": 630,
+      "hullMass": 580,
+      "masslock": 14
+    },
+    "retailCost": 35814211,
+    "slots": {
+      "common": [
+        6,
+        6,
+        5,
+        5,
+        7,
+        5,
+        4
+      ],
+      "hardpoints": [
+        3,
+        2,
+        2,
+        2,
+        2,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0
+      ],
+      "internal": [
+        6,
+        6,
+        5,
+        2,
+        2
+      ]
+    },
+    "defaults": {
+      "common": [
+        "6E",
+        "6E",
+        "5E",
+        "5E",
+        "7E",
+        "5E",
+        "4C"
+      ],
+      "hardpoints": [
+        0,
+        17,
+        17,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "internal": [
+        0,
+        "4j",
+        "03",
+        0,
+        "2h"
+      ]
+    }
+  }
+}

--- a/data/ships/imperial_eagle.json
+++ b/data/ships/imperial_eagle.json
@@ -1,0 +1,63 @@
+{
+  "imperial_eagle": {
+    "properties": {
+      "name": "Imperial Eagle",
+      "manufacturer": "Core Dynamics",
+      "class": 1,
+      "hullCost": 72186,
+      "speed": 303,
+      "boost": 405,
+      "boostEnergy": 9,
+      "agility": 6,
+      "baseShieldStrength": 80,
+      "baseArmour": 108,
+      "hullMass": 50,
+      "masslock": 6
+    },
+    "retailCost": 110833,
+    "slots": {
+      "common": [
+        3,
+        3,
+        3,
+        1,
+        2,
+        2,
+        2
+      ],
+      "hardpoints": [
+        2,
+        1,
+        1,
+        0
+      ],
+      "internal": [
+        3,
+        2,
+        1
+      ]
+    },
+    "defaults": {
+      "common": [
+        "3E",
+        "3E",
+        "3E",
+        "1E",
+        "2E",
+        "2E",
+        "2C"
+      ],
+      "hardpoints": [
+        0,
+        17,
+        17,
+        0
+      ],
+      "internal": [
+        "44",
+        "00",
+        "2h"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds the Federal Assault Ship, Federal Gunship and Imperial Eagle to the ship selection.

Note: Values for `boostEnergy` and `masslock` attributes are currently based on their parent ships. Should be updated as soon as data is available.
