### PR TITLE
Reload costs refinements

### DIFF
--- a/app/js/controllers/controller-outfit.js
+++ b/app/js/controllers/controller-outfit.js
@@ -607,7 +607,7 @@ angular.module('app').controller('OutfitController', ['$window', '$rootScope', '
       costs.push(item);
       total += item.ammoTotalCost;
     }
-    //total fuel, or if slider isn't at max, use that value and only if scoop not present
+    //calculate refuel costs if no scoop present
     if (!scoop) {
       item = {
         ammoName: 'fuel',

--- a/app/js/controllers/controller-outfit.js
+++ b/app/js/controllers/controller-outfit.js
@@ -609,12 +609,11 @@ angular.module('app').controller('OutfitController', ['$window', '$rootScope', '
     }
     //total fuel, or if slider isn't at max, use that value and only if scoop not present
     if (!scoop) {
-      q = $scope.fuel != ship.fuelCapacity ? $scope.fuel : ship.fuelCapacity;
       item = {
         ammoName: 'fuel',
-        ammoMax: q,
+        ammoMax: $scope.fuel,
         ammoUnitCost: 50,
-        ammoTotalCost: q * 50
+        ammoTotalCost: $scope.fuel * 50
       };
       costs.push(item);
       total += item.ammoTotalCost;

--- a/app/js/i18n/de.js
+++ b/app/js/i18n/de.js
@@ -115,6 +115,7 @@ angular.module('app').config(['$translateProvider', 'localeFormatProvider', func
     laden: 'Beladen',
     language: 'Sprache',
     large: 'Groß',
+    limpets: 'Krallen',
     ls: 'Lebenserhaltung',
     'Lightweight Alloy': 'Leichte Legierung',
     'lock factor': 'Massensperrefaktor',

--- a/app/js/i18n/en.js
+++ b/app/js/i18n/en.js
@@ -105,6 +105,7 @@ angular.module('app').config(['$translateProvider', function($translateProvider)
     laden: 'laden',
     language: 'language',
     large: 'large',
+    'limpets': 'Limpets',
     ls: 'life support',
     'Lightweight Alloy': 'Lightweight Alloy',
     'lock factor': 'lock factor',

--- a/app/js/i18n/es.js
+++ b/app/js/i18n/es.js
@@ -115,6 +115,7 @@ angular.module('app').config(['$translateProvider', 'localeFormatProvider', func
     'large': 'Grande',
     'ls': 'Soporte vital',
     'Lightweight Alloy': 'Aleaci\u00f3n ligera',
+    'limpets': 'Drones',
     'lock factor': 'factor de bloqueo',
     'mass': 'Masa',
     'max': 'm\u00e1x',

--- a/app/js/i18n/fr.js
+++ b/app/js/i18n/fr.js
@@ -106,6 +106,7 @@ angular.module('app').config(['$translateProvider', 'localeFormatProvider', func
     large: 'large',
     ls: 'Systèmes de survie',
     'Lightweight Alloy': 'alliage léger',
+    'limpets': 'Patelles',
     'lock factor': 'facteur inhibition de masse',
     LS: 'SL',
     LY: 'AL',

--- a/app/js/i18n/ru.js
+++ b/app/js/i18n/ru.js
@@ -124,6 +124,7 @@ angular.module('app').config(['$translateProvider', 'localeFormatProvider', func
     large: 'большой',
     ls: 'Система жизнеобеспечения',
     'Lightweight Alloy': 'Легкий сплав',
+    'limpets': 'Дроны',
     'lock factor': 'Масс. блок',
     LS: 'Св.сек',
     LY: 'Св.лет',


### PR DESCRIPTION
- Change default reload costs sort order to descending unit cost
- Change fuel display as single entry instead of per tank using fuel slider for quantity
- Remove fuel cost if fuel scoop present
- Add limpet ammo if controllers and cargo capacity exist
